### PR TITLE
partial implementation of setext heading

### DIFF
--- a/src/parse/ast/block/leaf/mod.rs
+++ b/src/parse/ast/block/leaf/mod.rs
@@ -3,6 +3,7 @@ pub mod blank_line;
 pub mod fenced_code;
 pub mod indented_code;
 pub mod link_reference_definition;
+pub mod setext_heading;
 pub mod thematic_break;
 
 use crate::parse::traits::{Parse, Segments};

--- a/src/parse/ast/block/leaf/setext_heading.rs
+++ b/src/parse/ast/block/leaf/setext_heading.rs
@@ -1,0 +1,237 @@
+use crate::parse::segment::setext_heading::SetextHeadingUnderlineSegment;
+
+// TODO: finish this up.
+/// Setext heading block, as describe in the [spec](https://spec.commonmark.org/0.31.2/#setext-headings).
+///
+/// Unlike most blocks, setext headings are not parsed directly from the input. Rather, they
+/// are a possible byproduct of parsing a paragraph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetextHeading<'a> {
+    /* pub paragraph_segments: ParagraphSegments<'a>, */
+    pub underline_segment: SetextHeadingUnderlineSegment<'a>,
+}
+
+impl SetextHeading<'_> {
+    /* pub fn new(
+        paragraph_segments: ParagraphSegments<'a>,
+        underline_segment: SetextHeadingUnderlineSegment<'a>,
+    ) -> Self {
+        Self {
+            paragraph_segments,
+            underline_segment,
+        }
+    } */
+
+    #[allow(dead_code)]
+    pub fn level(&self) -> u8 {
+        self.underline_segment.level()
+    }
+}
+
+// TODO: maybe this try from is overkill? We could just do it outside.
+/* impl<'a> TryFrom<ParagraphSegmentsAndNext<'a>> for SetextHeading<'a> {
+    type Error = ParagraphSegmentsAndNext<'a>;
+
+    fn try_from(value: ParagraphSegmentsAndNext<'a>) -> Result<Self, Self::Error> {
+        let underline_segment = SetextHeadingUnderlineSegment::try_from(value.next_segment);
+        match underline_segment {
+            Ok(underline_segment) => Ok(Self::new(value.paragraph_segments, underline_segment)),
+            Err(_) => Err(value),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    mod try_from {
+        use crate::internal::parse::try_extract::TryExtract;
+        use segment::{Segment, SegmentStrExt};
+
+        use super::*;
+
+        macro_rules! failure_case {
+            ($name:ident, $paragraph_segments:expr, $next_segment:expr) => {
+                #[test]
+                fn $name() {
+                    let extract = ParagraphSegments::try_extract($paragraph_segments).unwrap();
+                    let paragraph_segments = extract.extracted;
+                    assert!(extract.remaining.is_none());
+
+                    let conversion_params =
+                        ParagraphSegmentsAndNext::new(paragraph_segments, $next_segment);
+
+                    assert_eq!(
+                        SetextHeading::try_from(conversion_params.clone()),
+                        Err(conversion_params)
+                    );
+                }
+            };
+        }
+
+        macro_rules! success_case {
+            ($name:ident, $all_segments:expr, $expected_level:expr) => {
+                #[test]
+                fn $name() {
+                    let all_segments: Vec<_> = $all_segments.collect();
+                    let mut paragraph_segments: Vec<_> = all_segments.clone();
+                    let next_segment = paragraph_segments.pop().unwrap();
+                    let extract =
+                        ParagraphSegments::try_extract(paragraph_segments.into_iter()).unwrap();
+                    assert!(extract.remaining.is_none());
+                    let conversion_params =
+                        ParagraphSegmentsAndNext::new(extract.extracted.clone(), next_segment);
+                    let setext_heading = SetextHeading::try_from(conversion_params).unwrap();
+
+                    assert_eq!(setext_heading.level(), $expected_level);
+                    assert_eq!(
+                        setext_heading,
+                        SetextHeading::new(extract.extracted, next_segment.try_into().unwrap()),
+                    );
+                }
+            };
+        }
+
+        failure_case!(
+            should_reject_an_empty_segment,
+            "aaa\n".lines(),
+            LineSegment::new(Segment::empty_at(location::Position::new(5, 2, 4)))
+        );
+        failure_case!(
+            should_reject_a_whitespace_segment,
+            "aaa\n".lines(),
+            LineSegment::new(Segment::new(location::Position::new(5, 2, 4), " \n"))
+        );
+        failure_case!(
+            should_reject_an_underline_segment_with_other_characters,
+            "aaa\n".lines(),
+            LineSegment::new(Segment::new(location::Position::new(5, 2, 4), "===a\n"))
+        );
+
+        success_case!(should_work_with_equals_underline, "aaa\n===\n".lines(), 1);
+        success_case!(should_work_with_hyphens_underline, "aaa\n---\n".lines(), 2);
+        success_case!(
+            should_work_with_a_single_character_underline,
+            "aaa\n=\n".lines(),
+            1
+        );
+        success_case!(
+            should_work_with_many_characters_underline,
+            "aaa\n============\n".lines(),
+            1
+        );
+        success_case!(
+            should_work_with_3_spaces_before_the_underline,
+            "aaa\n   ===\n".lines(),
+            1
+        );
+        success_case!(
+            should_work_with_trailing_whitespaces_underline,
+            "aaa\n===  \n".lines(),
+            1
+        );
+        success_case!(
+            should_work_with_multiline_paragraph,
+            "aaa\n         hello this is a continuation line\n===\n".lines(),
+            1
+        );
+    }
+} */
+
+/* #[cfg(test)]
+mod test {
+    use crate::parser::Parser;
+
+    use super::*;
+
+    mod try_from {
+        macro_rules! failure_case {
+            ($name:ident, $paragraph_segments:expr, $next_segment:expr) => {
+                #[test]
+                fn $name() {
+                    let paragraph = Paragraph::from($paragraph_segments);
+
+                    assert_eq!(
+                        SetextHeading::try_from((paragraph.clone(), $next_segment)),
+                        Err(paragraph)
+                    );
+                }
+            };
+        }
+
+        macro_rules! success_case {
+            ($name:ident, $all_segments:expr, $expected_level:expr) => {
+                #[test]
+                fn $name() {
+                    let all_segments: Vec<_> = $all_segments.collect();
+                    let mut paragraph_segments: Vec<_> = all_segments.clone();
+                    let setex_heading_segment = paragraph_segments.pop().unwrap();
+                    let paragraph = Paragraph::from(paragraph_segments);
+                    let setext_heading =
+                        SetextHeading::try_from((paragraph.clone(), setex_heading_segment))
+                            .unwrap();
+
+                    assert_eq!(setext_heading.level, $expected_level);
+                    assert_eq!(
+                        setext_heading.segments, all_segments,
+                        "unexpected setex heading segments"
+                    );
+                }
+            };
+        }
+
+        failure_case!(
+            should_reject_an_empty_segment,
+            "aaa\n".line_segments(),
+            Segment::empty_at(location::Position::new(5, 2, 4))
+        );
+        failure_case!(
+            should_reject_a_whitespace_segment,
+            "aaa\n".line_segments(),
+            Segment::new(location::Position::new(5, 2, 4), " \n")
+        );
+        failure_case!(
+            should_reject_an_underline_segment_with_other_characters,
+            "aaa\n".line_segments(),
+            Segment::new(location::Position::new(5, 2, 4), "===a\n")
+        );
+
+        success_case!(
+            should_work_with_equals_underline,
+            "aaa\n===\n".line_segments(),
+            1
+        );
+        success_case!(
+            should_work_with_hyphens_underline,
+            "aaa\n---\n".line_segments(),
+            2
+        );
+        success_case!(
+            should_work_with_a_single_character_underline,
+            "aaa\n=\n".line_segments(),
+            1
+        );
+        success_case!(
+            should_work_with_many_characters_underline,
+            "aaa\n============\n".line_segments(),
+            1
+        );
+        success_case!(
+            should_work_with_3_spaces_before_the_underline,
+            "aaa\n   ===\n".line_segments(),
+            1
+        );
+        success_case!(
+            should_work_with_trailing_whitespaces_underline,
+            "aaa\n===  \n".line_segments(),
+            1
+        );
+        success_case!(
+            should_work_with_multiline_paragraph,
+            "aaa\n         hello this is a continuation line\n===\n".line_segments(),
+            1
+        );
+    }
+}
+ */

--- a/src/parse/segment/mod.rs
+++ b/src/parse/segment/mod.rs
@@ -2,4 +2,5 @@ pub mod atx_heading;
 pub mod blank_line;
 pub mod fenced_code;
 pub mod indented_code;
+pub mod setext_heading;
 pub mod thematic_break;

--- a/src/parse/segment/setext_heading/equals.rs
+++ b/src/parse/segment/setext_heading/equals.rs
@@ -1,0 +1,93 @@
+use crate::parse::{
+    traits::{Parse, Segment},
+    utils::{indented_by_less_than_4, is_char, line},
+};
+use nom::{
+    IResult, Parser,
+    bytes::complete::take_while1,
+    character::complete::space0,
+    combinator::{eof, recognize},
+    error::ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetextHeadingEqualsUnderlineSegment<'a>(&'a str);
+
+impl<'a> SetextHeadingEqualsUnderlineSegment<'a> {
+    fn new(segment: &'a str) -> Self {
+        Self(segment)
+    }
+
+    pub fn level(&self) -> u8 {
+        1
+    }
+}
+
+impl<'a> Parse<'a> for SetextHeadingEqualsUnderlineSegment<'a> {
+    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
+    where
+        Self: Sized,
+    {
+        recognize(line.and_then((
+            indented_by_less_than_4,
+            take_while1(is_char('=')),
+            space0,
+            eof,
+        )))
+        .map(Self::new)
+        .parse(input)
+    }
+}
+
+impl<'a> Segment<'a> for SetextHeadingEqualsUnderlineSegment<'a> {
+    fn segment(&self) -> &'a str {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    mod parse {
+        use super::*;
+        use nom::error::Error;
+
+        macro_rules! failure_case {
+            ($test:ident, $segment:expr) => {
+                #[test]
+                fn $test() {
+                    assert!(
+                        SetextHeadingEqualsUnderlineSegment::parse::<Error<&str>>($segment)
+                            .is_err()
+                    );
+                }
+            };
+        }
+
+        macro_rules! success_case {
+            ($test:ident, $segment:expr) => {
+                #[test]
+                fn $test() {
+                    assert_eq!(
+                        SetextHeadingEqualsUnderlineSegment::parse::<Error<&str>>($segment),
+                        Ok(("", SetextHeadingEqualsUnderlineSegment::new($segment)))
+                    );
+                }
+            };
+        }
+
+        failure_case!(should_fail_with_empty, "");
+        failure_case!(should_fail_with_blank_line, "\n");
+        failure_case!(should_fail_with_4_idents, "    =\n");
+        failure_case!(should_fail_with_tab_ident, "\t=\n");
+        failure_case!(should_reject_trailing_characters, "=a\n");
+        failure_case!(should_fail_for_hyphens, "-\n");
+
+        success_case!(should_work_with_single_equal, "=\n");
+        success_case!(should_work_without_eol, "=");
+        success_case!(should_work_with_5_equals, "=====\n");
+        success_case!(should_work_with_3_idents, "   =\n");
+        success_case!(should_work_with_trailing_whitespace, "=  \n");
+    }
+}

--- a/src/parse/segment/setext_heading/hyphens.rs
+++ b/src/parse/segment/setext_heading/hyphens.rs
@@ -1,0 +1,93 @@
+use crate::parse::{
+    traits::{Parse, Segment},
+    utils::{indented_by_less_than_4, is_char, line},
+};
+use nom::{
+    IResult, Parser,
+    bytes::complete::take_while1,
+    character::complete::space0,
+    combinator::{eof, recognize},
+    error::ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetextHeadingHyphensUnderlineSegment<'a>(&'a str);
+
+impl<'a> SetextHeadingHyphensUnderlineSegment<'a> {
+    fn new(segment: &'a str) -> Self {
+        Self(segment)
+    }
+
+    pub fn level(&self) -> u8 {
+        2
+    }
+}
+
+impl<'a> Parse<'a> for SetextHeadingHyphensUnderlineSegment<'a> {
+    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
+    where
+        Self: Sized,
+    {
+        recognize(line.and_then((
+            indented_by_less_than_4,
+            take_while1(is_char('-')),
+            space0,
+            eof,
+        )))
+        .map(Self::new)
+        .parse(input)
+    }
+}
+
+impl<'a> Segment<'a> for SetextHeadingHyphensUnderlineSegment<'a> {
+    fn segment(&self) -> &'a str {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    mod parse {
+        use super::*;
+        use nom::error::Error;
+
+        macro_rules! failure_case {
+            ($test:ident, $segment:expr) => {
+                #[test]
+                fn $test() {
+                    assert!(
+                        SetextHeadingHyphensUnderlineSegment::parse::<Error<&str>>($segment)
+                            .is_err()
+                    );
+                }
+            };
+        }
+
+        macro_rules! success_case {
+            ($test:ident, $segment:expr) => {
+                #[test]
+                fn $test() {
+                    assert_eq!(
+                        SetextHeadingHyphensUnderlineSegment::parse::<Error<&str>>($segment),
+                        Ok(("", SetextHeadingHyphensUnderlineSegment::new($segment)))
+                    );
+                }
+            };
+        }
+
+        failure_case!(should_fail_with_empty, "");
+        failure_case!(should_fail_with_blank_line, "\n");
+        failure_case!(should_fail_with_4_idents, "    -\n");
+        failure_case!(should_fail_with_tab_ident, "\t-\n");
+        failure_case!(should_reject_trailing_characters, "-a\n");
+        failure_case!(should_fail_for_equals, "=\n");
+
+        success_case!(should_work_with_single_equal, "-\n");
+        success_case!(should_work_without_eol, "-");
+        success_case!(should_work_with_5_hyphens, "-----\n");
+        success_case!(should_work_with_3_idents, "   -\n");
+        success_case!(should_work_with_trailing_whitespace, "-  \n");
+    }
+}

--- a/src/parse/segment/setext_heading/mod.rs
+++ b/src/parse/segment/setext_heading/mod.rs
@@ -1,0 +1,106 @@
+mod equals;
+mod hyphens;
+
+use crate::parse::traits::{Parse, Segment};
+pub use equals::*;
+pub use hyphens::*;
+use nom::{IResult, Parser, branch::alt, error::ParseError};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SetextHeadingUnderlineSegment<'a> {
+    Equals(SetextHeadingEqualsUnderlineSegment<'a>),
+    Hyphens(SetextHeadingHyphensUnderlineSegment<'a>),
+}
+
+impl SetextHeadingUnderlineSegment<'_> {
+    pub fn level(&self) -> u8 {
+        match self {
+            Self::Equals(segment) => segment.level(),
+            Self::Hyphens(segment) => segment.level(),
+        }
+    }
+}
+
+impl<'a> From<SetextHeadingEqualsUnderlineSegment<'a>> for SetextHeadingUnderlineSegment<'a> {
+    fn from(segment: SetextHeadingEqualsUnderlineSegment<'a>) -> Self {
+        Self::Equals(segment)
+    }
+}
+
+impl<'a> From<SetextHeadingHyphensUnderlineSegment<'a>> for SetextHeadingUnderlineSegment<'a> {
+    fn from(segment: SetextHeadingHyphensUnderlineSegment<'a>) -> Self {
+        Self::Hyphens(segment)
+    }
+}
+
+impl<'a> Parse<'a> for SetextHeadingUnderlineSegment<'a> {
+    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
+    where
+        Self: Sized,
+    {
+        alt((
+            SetextHeadingEqualsUnderlineSegment::parse.map(Self::from),
+            SetextHeadingHyphensUnderlineSegment::parse.map(Self::from),
+        ))
+        .parse(input)
+    }
+}
+
+impl<'a> Segment<'a> for SetextHeadingUnderlineSegment<'a> {
+    fn segment(&self) -> &'a str {
+        match self {
+            Self::Equals(segment) => segment.segment(),
+            Self::Hyphens(segment) => segment.segment(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    mod parse {
+        use super::*;
+        use crate::parse::traits::StrictParse;
+        use nom::error::Error;
+
+        macro_rules! failure_case {
+            ($test:ident, $segment:expr) => {
+                #[test]
+                fn $test() {
+                    assert!(SetextHeadingUnderlineSegment::parse::<Error<&str>>($segment).is_err());
+                }
+            };
+        }
+
+        macro_rules! success_case {
+            ($test:ident, $segment:expr, $expected:expr) => {
+                #[test]
+                fn $test() {
+                    assert_eq!(
+                        SetextHeadingUnderlineSegment::parse::<Error<&str>>($segment),
+                        Ok(("", $expected))
+                    );
+                }
+            };
+        }
+
+        failure_case!(should_reject_empty, "");
+        failure_case!(should_reject_blank_line, "\n");
+
+        success_case!(
+            should_accept_equals,
+            "=\n",
+            SetextHeadingUnderlineSegment::Equals(
+                SetextHeadingEqualsUnderlineSegment::strict_parse("=\n")
+            )
+        );
+        success_case!(
+            should_accept_hyphens,
+            "-\n",
+            SetextHeadingUnderlineSegment::Hyphens(
+                SetextHeadingHyphensUnderlineSegment::strict_parse("-\n")
+            )
+        );
+    }
+}


### PR DESCRIPTION
- Setext headings are obtained while parsing paragraphs, and not
parsed directly. Therefore, we also need to write the code to parse
paragraphs to finish up the "parsing" logic of setext headings.
- The code was imported and commented out, to be finished later,
when finalizing paragraph parse logic.
