### PR TITLE
new parse interface

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.87.0"
 components = ["rustfmt", "clippy"]

--- a/src/api/ast/block/leaf/indented_code.rs
+++ b/src/api/ast/block/leaf/indented_code.rs
@@ -104,26 +104,23 @@ mod test {
 
     mod segments {
         use super::*;
-        use crate::parse::traits::ParseWhole;
-        use nom::error::Error;
+        use crate::parse::traits::StrictParse;
         use std::vec;
 
         #[test]
         fn should_work_with_single_segment() {
-            let indented_code =
-                IndentedCode::parse_whole::<Error<&str>>("    This is indented code\n").unwrap();
+            let indented_code = IndentedCode::strict_parse("    This is indented code\n");
             let segments = indented_code.segments().collect::<Vec<_>>();
             assert_eq!(segments, vec!["    This is indented code\n"]);
         }
 
         #[test]
         fn should_work_with_multiple_segments() {
-            let indented_code = IndentedCode::parse_whole::<Error<&str>>(
+            let indented_code = IndentedCode::strict_parse(
                 r"    This is indented code
 
     This is the closing segment.",
-            )
-            .unwrap();
+            );
             let segments = indented_code.segments().collect::<Vec<_>>();
             assert_eq!(
                 segments,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,8 @@ pub mod render;
 
 use api::ast::Tree;
 pub use api::*;
-use nom::error::Error;
-use parse::traits::ParseWhole;
+use parse::traits::StrictParse;
 
 pub fn parse(input: &str) -> Tree {
-    Tree::parse_whole::<Error<&str>>(input).expect("unexpected error parsing markdown")
+    Tree::strict_parse(input)
 }

--- a/src/parse/ast/block/leaf/atx_heading.rs
+++ b/src/parse/ast/block/leaf/atx_heading.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::AtxHeading,
     parse::{
-        traits::Parse,
+        traits::NomParse,
         utils::{indented_by_less_than_4, is_char, line},
     },
 };
@@ -10,8 +10,8 @@ use nom::{
     combinator::consumed, error::ParseError, sequence::preceded,
 };
 
-impl<'a> Parse<'a> for AtxHeading<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error> {
+impl<'a> NomParse<'a> for AtxHeading<'a> {
+    fn nom_parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error> {
         consumed(line.and_then(parts()))
             .map(|(text, (level, title))| Self::new(text, title, level))
             .parse(input)

--- a/src/parse/ast/block/leaf/blank_line.rs
+++ b/src/parse/ast/block/leaf/blank_line.rs
@@ -1,4 +1,4 @@
-use crate::{ast::BlankLine, parse::traits::Parse};
+use crate::{ast::BlankLine, parse::traits::NomParse};
 use nom::{
     Parser,
     branch::alt,
@@ -7,8 +7,8 @@ use nom::{
     error::ParseError,
 };
 
-impl<'a> Parse<'a> for BlankLine<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> nom::IResult<&'a str, Self, Error> {
+impl<'a> NomParse<'a> for BlankLine<'a> {
+    fn nom_parse<Error: ParseError<&'a str>>(input: &'a str) -> nom::IResult<&'a str, Self, Error> {
         consumed(alt(((space0, line_ending), (space1, eof))))
             .map(|(segment, _)| Self::new(segment))
             .parse(input)

--- a/src/parse/ast/block/leaf/fenced_code/mod.rs
+++ b/src/parse/ast/block/leaf/fenced_code/mod.rs
@@ -3,16 +3,16 @@ mod tildes;
 
 use crate::{
     ast::{BackticksFencedCode, FencedCode, TildesFencedCode},
-    parse::traits::Parse,
+    parse::{
+        input::{Input, ParseResult},
+        parser::{Map, Parser, one_of},
+        traits::Parse,
+    },
 };
-use nom::{Parser, branch::alt, error::ParseError};
 
-impl<'a> Parse<'a> for FencedCode<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> nom::IResult<&'a str, Self, Error>
-    where
-        Self: Sized,
-    {
-        alt((
+impl<'a> Parse<&'a str> for FencedCode<'a> {
+    fn parse<I: Input<Item = &'a str>>(input: I) -> ParseResult<I, Self> {
+        one_of((
             BackticksFencedCode::parse.map(Self::from),
             TildesFencedCode::parse.map(Self::from),
         ))

--- a/src/parse/ast/block/leaf/fenced_code/tildes.rs
+++ b/src/parse/ast/block/leaf/fenced_code/tildes.rs
@@ -1,55 +1,67 @@
 use crate::{
-    Segment,
     ast::TildesFencedCode,
     parse::{
+        input::{Input, ParseQuantity, ParseResult},
+        parser::{Map, Parser, Validate},
         segment::fenced_code::{TildesFencedCodeClosingSegment, TildesFencedCodeOpeningSegment},
         traits::Parse,
-        utils::line,
     },
 };
-use nom::{IResult, Parser, combinator::recognize, error::ParseError};
 
-impl<'a> Parse<'a> for TildesFencedCode<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error> {
-        let (mut remaining, opening_segment) =
-            TildesFencedCodeOpeningSegment::parse::<Error>(input)?;
-        let mut content_segments = Vec::new();
-        // We then loop until we find a closing segment for the opening segment or the end of input.
-        let (remaining, closing_segment) = loop {
-            let Ok((inner, closing_segment)) =
-                TildesFencedCodeClosingSegment::parse::<Error>(remaining)
-            // If it's not a closing segment, we just add it to the content.
-            else {
-                // Take the line. and count it as content segment.
-                match recognize(line::<Error>).parse(remaining) {
-                    Ok((inner, line)) => {
-                        content_segments.push(line);
-                        remaining = inner;
-                        continue;
-                    }
-                    Err(_) => {
-                        // If we can't parse a line, we are done.
-                        assert_eq!(remaining, "");
-                        break ("", None);
-                    }
-                }
-            };
-            // If it is a closing segment, we still need to check that its fence length is long enough.
-            if closing_segment.closes(&opening_segment) {
-                // It's a match for the opening segment, so we are done.
-                break (inner, Some(closing_segment));
-            } else {
-                // Otherwise, we treat it as regular content.
-                content_segments.push(closing_segment.segment());
-                remaining = inner;
-                continue;
+enum ContentOrClosingSegment<'a> {
+    Content(&'a str),
+    Closing(TildesFencedCodeClosingSegment<'a>),
+}
+
+fn content_or_closing_segment<'a, I: Input<Item = &'a str>>(
+    opening: &TildesFencedCodeOpeningSegment<'a>,
+) -> impl Fn(I) -> ParseResult<I, ContentOrClosingSegment<'a>> {
+    |input: I| {
+        if input.is_empty() {
+            return Err(input);
+        }
+        match TildesFencedCodeClosingSegment::parse
+            .validate(|segment: &TildesFencedCodeClosingSegment| segment.closes(opening))
+            .map(ContentOrClosingSegment::Closing)
+            .parse(input)
+        {
+            Ok((remaning, closing)) => Ok((remaning, closing)),
+            Err(input) => {
+                // If it's not a closing segment, then it's content. It's safe to unwrap because we have already
+                // checked that the input is not empty.
+                let segment = input.first().unwrap();
+                input.parsed(
+                    ParseQuantity::Items(1),
+                    ContentOrClosingSegment::Content(segment),
+                )
             }
-        };
+        }
+    }
+}
 
-        Ok((
-            remaining,
-            Self::new(opening_segment, content_segments, closing_segment),
-        ))
+impl<'a> Parse<&'a str> for TildesFencedCode<'a> {
+    fn parse<I: Input<Item = &'a str>>(input: I) -> ParseResult<I, Self> {
+        let (mut remaining, opening) = TildesFencedCodeOpeningSegment::parse(input)?;
+        let mut content_segments = Vec::new();
+        loop {
+            let result = content_or_closing_segment(&opening).parse(remaining);
+            match result {
+                Ok((inner, ContentOrClosingSegment::Content(segment))) => {
+                    remaining = inner;
+                    content_segments.push(segment);
+                }
+                Ok((inner, ContentOrClosingSegment::Closing(closing_segment))) => {
+                    return Ok((
+                        inner,
+                        Self::new(opening, content_segments, Some(closing_segment)),
+                    ));
+                }
+                Err(input) => {
+                    // If we get there it's because we ran out of input.
+                    return Ok((input, Self::new(opening, content_segments, None)));
+                }
+            }
+        }
     }
 }
 

--- a/src/parse/ast/block/leaf/mod.rs
+++ b/src/parse/ast/block/leaf/mod.rs
@@ -6,15 +6,16 @@ pub mod thematic_break;
 
 use crate::{
     ast::{AtxHeading, BlankLine, FencedCode, IndentedCode, Leaf, ThematicBreak},
-    parse::traits::Parse,
+    parse::{
+        input::{Input, ParseResult},
+        parser::{Map, Parser, one_of},
+        traits::Parse,
+    },
 };
-use nom::{Parser, branch::alt};
 
-impl<'a> Parse<'a> for Leaf<'a> {
-    fn parse<Error: nom::error::ParseError<&'a str>>(
-        input: &'a str,
-    ) -> nom::IResult<&'a str, Self, Error> {
-        alt((
+impl<'a> Parse<&'a str> for Leaf<'a> {
+    fn parse<I: Input<Item = &'a str>>(input: I) -> ParseResult<I, Self> {
+        one_of((
             AtxHeading::parse.map(Leaf::AtxHeading),
             BlankLine::parse.map(Leaf::BlankLine),
             FencedCode::parse.map(Leaf::FencedCode),

--- a/src/parse/ast/block/leaf/thematic_break.rs
+++ b/src/parse/ast/block/leaf/thematic_break.rs
@@ -1,5 +1,5 @@
 use crate::ast::ThematicBreak;
-use crate::parse::traits::Parse;
+use crate::parse::traits::NomParse;
 use crate::parse::utils::{indented_by_less_than_4, is_one_of, line};
 use nom::IResult;
 use nom::error::ParseError;
@@ -57,8 +57,8 @@ fn underscores<'a, Error: ParseError<&'a str>>()
     ))
 }
 
-impl<'a> Parse<'a> for ThematicBreak<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error> {
+impl<'a> NomParse<'a> for ThematicBreak<'a> {
+    fn nom_parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error> {
         consumed(line.and_then(thematic_break()))
             .map(|(segment, _)| Self::new(segment))
             .parse(input)

--- a/src/parse/ast/block/mod.rs
+++ b/src/parse/ast/block/mod.rs
@@ -3,14 +3,15 @@ pub mod leaf;
 
 use crate::{
     ast::{Block, Leaf},
-    parse::traits::Parse,
+    parse::{
+        input::{Input, ParseResult},
+        parser::{Map, Parser},
+        traits::Parse,
+    },
 };
-use nom::Parser;
 
-impl<'a> Parse<'a> for Block<'a> {
-    fn parse<Error: nom::error::ParseError<&'a str>>(
-        input: &'a str,
-    ) -> nom::IResult<&'a str, Self, Error> {
+impl<'a> Parse<&'a str> for Block<'a> {
+    fn parse<I: Input<Item = &'a str>>(input: I) -> ParseResult<I, Self> {
         Leaf::parse.map(Block::Leaf).parse(input)
     }
 }

--- a/src/parse/ast/mod.rs
+++ b/src/parse/ast/mod.rs
@@ -1,13 +1,14 @@
 pub mod block;
 
-use super::traits::Parse;
+use super::{
+    input::{Input, ParseResult},
+    parser::{Map, Parser, ZeroToMany},
+    traits::Parse,
+};
 use crate::ast::{Block, Tree};
-use nom::{IResult, Parser, multi::many0};
 
-impl<'a> Parse<'a> for Tree<'a> {
-    fn parse<Error: nom::error::ParseError<&'a str>>(
-        input: &'a str,
-    ) -> IResult<&'a str, Self, Error> {
-        many0(Block::parse).map(Self::from).parse(input)
+impl<'a> Parse<&'a str> for Tree<'a> {
+    fn parse<I: Input<Item = &'a str>>(input: I) -> ParseResult<I, Self> {
+        Block::parse.zero_to_many().map(Tree::from).parse(input)
     }
 }

--- a/src/parse/inline/link/link_destination/bracketed.rs
+++ b/src/parse/inline/link/link_destination/bracketed.rs
@@ -1,12 +1,12 @@
 use crate::inline::link::BracketedLinkDestination;
-use crate::parse::{traits::Parse, utils::escaped_sequence};
+use crate::parse::{traits::NomParse, utils::escaped_sequence};
 use nom::{
     IResult, Parser, branch::alt, bytes::complete::is_not, character::complete::char,
     combinator::recognize, error::ParseError, multi::many0,
 };
 
-impl<'a> Parse<'a> for BracketedLinkDestination<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
+impl<'a> NomParse<'a> for BracketedLinkDestination<'a> {
+    fn nom_parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
     where
         Self: Sized,
     {

--- a/src/parse/inline/link/link_destination/mod.rs
+++ b/src/parse/inline/link/link_destination/mod.rs
@@ -2,17 +2,17 @@ mod bracketed;
 mod unbracketed;
 
 use crate::inline::link::{BracketedLinkDestination, LinkDestination, UnbracketedLinkDestination};
-use crate::parse::traits::Parse;
+use crate::parse::traits::NomParse;
 use nom::{IResult, Parser, branch::alt, error::ParseError};
 
-impl<'a> Parse<'a> for LinkDestination<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
+impl<'a> NomParse<'a> for LinkDestination<'a> {
+    fn nom_parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
     where
         Self: Sized,
     {
         alt((
-            BracketedLinkDestination::parse.map(Self::from),
-            UnbracketedLinkDestination::parse.map(Self::from),
+            BracketedLinkDestination::nom_parse.map(Self::from),
+            UnbracketedLinkDestination::nom_parse.map(Self::from),
         ))
         .parse(input)
     }

--- a/src/parse/inline/link/link_destination/unbracketed.rs
+++ b/src/parse/inline/link/link_destination/unbracketed.rs
@@ -1,6 +1,6 @@
 use crate::inline::link::UnbracketedLinkDestination;
 use crate::parse::{
-    traits::Parse,
+    traits::NomParse,
     utils::{parentheseses_balance, take_one},
 };
 use nom::{
@@ -16,8 +16,8 @@ a nonempty sequence of characters that does not start with <, does not include A
 and includes parentheses only if (a) they are backslash-escaped or (b) they are part of a balanced pair of unescaped parentheses.
 (Implementations may impose limits on parentheses nesting to avoid performance issues, but at least three levels of nesting should be supported.)
 */
-impl<'a> Parse<'a> for UnbracketedLinkDestination<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
+impl<'a> NomParse<'a> for UnbracketedLinkDestination<'a> {
+    fn nom_parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
     where
         Self: Sized,
     {

--- a/src/parse/inline/link/link_label.rs
+++ b/src/parse/inline/link/link_label.rs
@@ -1,6 +1,6 @@
 use crate::{
     inline::link::LinkLabel,
-    parse::{traits::Parse, utils::escaped_sequence},
+    parse::{traits::NomParse, utils::escaped_sequence},
 };
 use nom::{
     IResult, Parser,
@@ -18,8 +18,8 @@ Between these brackets there must be at least one character that is not a space,
 Unescaped square bracket characters are not allowed inside the opening and closing square brackets of link labels.
 A link label can have at most 999 characters inside the square brackets.
 */
-impl<'a> Parse<'a> for LinkLabel<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
+impl<'a> NomParse<'a> for LinkLabel<'a> {
+    fn nom_parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
     where
         Self: Sized,
     {

--- a/src/parse/inline/link/link_title/double_quotes.rs
+++ b/src/parse/inline/link/link_title/double_quotes.rs
@@ -1,20 +1,18 @@
 use crate::{
     inline::link::DoubleQuotesLinkTitle,
     parse::{
+        input::{Input, ParseResult},
+        parser::{Map, Parser, one_of},
         segment::link_title::{
             DoubleQuotesLinkTitleMultiSegments, DoubleQuotesLinkTitleSingleSegment,
         },
         traits::Parse,
     },
 };
-use nom::{IResult, Parser, branch::alt, error::ParseError};
 
-impl<'a> Parse<'a> for DoubleQuotesLinkTitle<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
-    where
-        Self: Sized,
-    {
-        alt((
+impl<'a> Parse<&'a str> for DoubleQuotesLinkTitle<'a> {
+    fn parse<I: Input<Item = &'a str>>(input: I) -> ParseResult<I, Self> {
+        one_of((
             DoubleQuotesLinkTitleSingleSegment::parse.map(Self::Single),
             DoubleQuotesLinkTitleMultiSegments::parse.map(Self::Multi),
         ))

--- a/src/parse/inline/link/link_title/mod.rs
+++ b/src/parse/inline/link/link_title/mod.rs
@@ -4,19 +4,19 @@ mod single_quotes;
 
 use crate::{
     inline::link::{DoubleQuotesLinkTitle, LinkTitle, ParenthesesLinkTitle, SingleQuotesLinkTitle},
-    parse::traits::Parse,
+    parse::{
+        input::{Input, ParseResult},
+        parser::{Map, Parser, one_of},
+        traits::Parse,
+    },
 };
-use nom::{IResult, Parser, branch::alt, error::ParseError};
 
-impl<'a> Parse<'a> for LinkTitle<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
-    where
-        Self: Sized,
-    {
-        alt((
-            SingleQuotesLinkTitle::parse.map(Self::from),
-            DoubleQuotesLinkTitle::parse.map(Self::from),
-            ParenthesesLinkTitle::parse.map(Self::from),
+impl<'a> Parse<&'a str> for LinkTitle<'a> {
+    fn parse<I: Input<Item = &'a str>>(input: I) -> ParseResult<I, Self> {
+        one_of((
+            SingleQuotesLinkTitle::parse.map(Self::SingleQuotes),
+            DoubleQuotesLinkTitle::parse.map(Self::DoubleQuotes),
+            ParenthesesLinkTitle::parse.map(Self::Parentheses),
         ))
         .parse(input)
     }

--- a/src/parse/inline/link/link_title/parentheses.rs
+++ b/src/parse/inline/link/link_title/parentheses.rs
@@ -1,20 +1,18 @@
 use crate::{
     inline::link::ParenthesesLinkTitle,
     parse::{
+        input::{Input, ParseResult},
+        parser::{Map, Parser, one_of},
         segment::link_title::{
             ParenthesesLinkTitleMultiSegments, ParenthesesLinkTitleSingleSegment,
         },
         traits::Parse,
     },
 };
-use nom::{IResult, Parser, branch::alt, error::ParseError};
 
-impl<'a> Parse<'a> for ParenthesesLinkTitle<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
-    where
-        Self: Sized,
-    {
-        alt((
+impl<'a> Parse<&'a str> for ParenthesesLinkTitle<'a> {
+    fn parse<I: Input<Item = &'a str>>(input: I) -> ParseResult<I, Self> {
+        one_of((
             ParenthesesLinkTitleSingleSegment::parse.map(Self::Single),
             ParenthesesLinkTitleMultiSegments::parse.map(Self::Multi),
         ))

--- a/src/parse/inline/link/link_title/single_quotes.rs
+++ b/src/parse/inline/link/link_title/single_quotes.rs
@@ -1,20 +1,18 @@
 use crate::{
     inline::link::SingleQuotesLinkTitle,
     parse::{
+        input::{Input, ParseResult},
+        parser::{Map, Parser, one_of},
         segment::link_title::{
             SingleQuotesLinkTitleMultiSegments, SingleQuotesLinkTitleSingleSegment,
         },
         traits::Parse,
     },
 };
-use nom::{IResult, Parser, branch::alt, error::ParseError};
 
-impl<'a> Parse<'a> for SingleQuotesLinkTitle<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
-    where
-        Self: Sized,
-    {
-        alt((
+impl<'a> Parse<&'a str> for SingleQuotesLinkTitle<'a> {
+    fn parse<I: Input<Item = &'a str>>(input: I) -> ParseResult<I, Self> {
+        one_of((
             SingleQuotesLinkTitleSingleSegment::parse.map(Self::Single),
             SingleQuotesLinkTitleMultiSegments::parse.map(Self::Multi),
         ))

--- a/src/parse/input.rs
+++ b/src/parse/input.rs
@@ -1,0 +1,110 @@
+pub enum ParseQuantity {
+    /// The quantity of items parsed.
+    Items(usize),
+    // TODO: this should be a bound on the item of input. It should be able to "consume" itself for a given number of bytes.
+    /// The quantity of bytes parsed.
+    Bytes(usize),
+}
+
+pub type ParseResult<I, T> = Result<(I, T), I>;
+
+/// A trait to regroup different input types.
+///
+/// Some frequent algorithms like to walk back on inputs. To do so, we could implement rewinding
+/// semantics here, but for the sake of simplicity, we decided to first start with using the [Clone]
+/// trait. This is why [Input] are also expected to be [Clone]. That being said, in the context of
+/// this program, [Input]s are lightweight and they also implement [Copy], making the clone operation
+/// quite cheap.
+pub trait Input
+where
+    Self: Sized + Clone,
+{
+    type Item;
+
+    /// Returns whether the input is empty.
+    fn is_empty(&self) -> bool;
+
+    /// Returns the input with the given quantity consumed.
+    fn consumed(&self, quantity: ParseQuantity) -> Self;
+
+    /// Returns the first item of the input.
+    ///
+    /// An empty string signifies the end of the input.
+    fn first(&self) -> Option<Self::Item> {
+        self.items().next()
+    }
+
+    /// Returns an iterator over the items of the input.
+    fn items(&self) -> impl Iterator<Item = Self::Item>;
+
+    /// Returns a successful parse result, stripping the input of the given quantity parsed.
+    fn parsed<T>(self, quantity: ParseQuantity, value: T) -> ParseResult<Self, T>
+    where
+        T: Sized,
+    {
+        let remaining = self.consumed(quantity);
+        Ok((remaining, value))
+    }
+
+    /// Returns a failed parse result, returning the input untouched.
+    fn failed<T>(self) -> ParseResult<Self, T>
+    where
+        T: Sized,
+    {
+        Err(self)
+    }
+}
+
+trait StrInput<'a> {
+    fn bytes_for_items(&self, count: usize) -> usize;
+    fn quantity_in_bytes(&self, quantity: ParseQuantity) -> usize;
+}
+
+impl<'a> StrInput<'a> for &'a str {
+    fn bytes_for_items(&self, count: usize) -> usize {
+        let mut index = 0;
+        let mut bytes = 0;
+        for segment in self.items() {
+            bytes += segment.len();
+            index += 1;
+            if index == count {
+                return bytes;
+            }
+        }
+        panic!("invalid segment count {count} for input {self}");
+    }
+
+    fn quantity_in_bytes(&self, quantity: ParseQuantity) -> usize {
+        match quantity {
+            ParseQuantity::Items(count) => self.bytes_for_items(count),
+            // Validate bytes
+            ParseQuantity::Bytes(count) => {
+                assert!(
+                    count >= 1 && count <= self.len(),
+                    "invalid byte count {} for input {}, expected range [{}, {}]",
+                    count,
+                    self,
+                    1,
+                    self.len()
+                );
+                count
+            }
+        }
+    }
+}
+
+impl<'a> Input for &'a str {
+    type Item = &'a str;
+
+    fn is_empty(&self) -> bool {
+        str::is_empty(self)
+    }
+
+    fn consumed(&self, quantity: ParseQuantity) -> Self {
+        &self[self.quantity_in_bytes(quantity)..]
+    }
+
+    fn items(&self) -> impl Iterator<Item = Self::Item> {
+        self.split_inclusive("\n")
+    }
+}

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -1,5 +1,7 @@
 pub mod ast;
 pub mod inline;
+pub mod input;
+pub mod parser;
 pub mod segment;
 #[cfg(test)]
 mod test_utils;

--- a/src/parse/parser/and.rs
+++ b/src/parse/parser/and.rs
@@ -1,0 +1,135 @@
+use super::{Parser, ParserMut, ParserOnce};
+use crate::parse::input::{Input, ParseResult};
+use std::fmt::Debug;
+
+pub trait And<R>: Sized {
+    fn and(self, right: R) -> AndParser<Self, R>;
+}
+
+impl<R, T> And<R> for T {
+    fn and(self, right: R) -> AndParser<Self, R> {
+        and(self, right)
+    }
+}
+
+pub fn and<L, R>(left: L, right: R) -> AndParser<L, R> {
+    AndParser::new(left, right)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AndParser<L, R> {
+    left: L,
+    right: R,
+}
+
+impl<L, R> AndParser<L, R> {
+    fn new(left: L, right: R) -> Self {
+        Self { left, right }
+    }
+}
+
+impl<I, L, R> Parser<I> for AndParser<L, R>
+where
+    I: Input,
+    L: Parser<I>,
+    R: Parser<I>,
+{
+    type Output = (L::Output, R::Output);
+
+    fn parse(&self, input: I) -> ParseResult<I, Self::Output> {
+        let (remaining, left) = self.left.parse(input.clone())?;
+        match self.right.parse(remaining) {
+            Ok((remaining, right)) => Ok((remaining, (left, right))),
+            // An error invalidates the whole parser and we rewind from the beginning.
+            Err(_) => Err(input),
+        }
+    }
+}
+
+impl<I, L, R> ParserMut<I> for AndParser<L, R>
+where
+    I: Input,
+    L: ParserMut<I>,
+    R: ParserMut<I>,
+{
+    type Output = (L::Output, R::Output);
+
+    fn parse_mut(&mut self, input: I) -> ParseResult<I, Self::Output> {
+        let (remaining, left) = self.left.parse_mut(input.clone())?;
+        match self.right.parse_mut(remaining) {
+            Ok((remaining, right)) => Ok((remaining, (left, right))),
+            // An error invalidates the whole parser and we rewind from the beginning.
+            Err(_) => Err(input),
+        }
+    }
+}
+
+impl<I, L, R> ParserOnce<I> for AndParser<L, R>
+where
+    I: Input,
+    L: ParserOnce<I>,
+    R: ParserOnce<I>,
+{
+    type Output = (L::Output, R::Output);
+
+    fn parse_once(self, input: I) -> ParseResult<I, Self::Output> {
+        let (remaining, left) = self.left.parse_once(input.clone())?;
+        match self.right.parse_once(remaining) {
+            Ok((remaining, right)) => Ok((remaining, (left, right))),
+            // An error invalidates the whole parser and we rewind from the beginning.
+            Err(_) => Err(input),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::parse::{
+        parser::{take_chars, typed_fail},
+        utils::alias,
+    };
+
+    alias!(fail, typed_fail![&'static str]);
+
+    #[test]
+    fn test_rejects_when_left_rejects() {
+        let parser = and(fail!(), take_chars(4));
+        let result = parser.parse("test");
+        assert_eq!(Err("test"), result);
+    }
+
+    #[test]
+    fn test_rejects_when_right_rejects() {
+        let parser = take_chars(4).and(fail!());
+        let result = parser.parse("test");
+        // Even though the first parser succeeds and consumes the first 4 bytes, a failure in the
+        // second should rewind the whole thang.
+        assert_eq!(Err("test"), result);
+    }
+
+    #[test]
+    fn test_success_when_both_succeed() {
+        let parser = take_chars(4).and(take_chars(4));
+        let result = parser.parse("test1234");
+        assert_eq!(Ok(("", ("test", "1234"))), result);
+    }
+
+    #[test]
+    fn test_parse_mut_when_parsers_are_mut() {
+        let mut parser = take_chars(4);
+        let left = |input| parser.parse_mut(input);
+        let mut parser = left.and(take_chars(4));
+        let result = parser.parse_mut("test1234");
+        assert_eq!(Ok(("", ("test", "1234"))), result);
+    }
+
+    #[test]
+    fn test_parse_once_when_parsers_are_once() {
+        let parser = take_chars(4);
+        let left = |input| parser.parse_once(input);
+        let parser = left.and(take_chars(4));
+        let result = parser.parse_once("test1234");
+        assert_eq!(Ok(("", ("test", "1234"))), result);
+    }
+}

--- a/src/parse/parser/fail.rs
+++ b/src/parse/parser/fail.rs
@@ -1,0 +1,119 @@
+use super::{Parser, ParserMut, ParserOnce};
+use crate::parse::input::{Input, ParseResult};
+
+macro_rules! typed_crash {
+    ($type: ty) => {
+        crate::parse::parser::typed_crash_parser::<$type>()
+    };
+}
+pub(super) use typed_crash;
+
+pub fn typed_crash_parser<O>() -> CrashParser<O> {
+    CrashParser::new()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CrashParser<O> {
+    _phantom: std::marker::PhantomData<O>,
+}
+
+impl<O> CrashParser<O> {
+    fn new() -> Self {
+        Self {
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<I, O> Parser<I> for CrashParser<O>
+where
+    I: Input,
+{
+    type Output = O;
+
+    fn parse(&self, _: I) -> ParseResult<I, Self::Output> {
+        panic!("crash parser invoked!");
+    }
+}
+
+impl<I, O> ParserMut<I> for CrashParser<O>
+where
+    I: Input,
+{
+    type Output = O;
+
+    fn parse_mut(&mut self, input: I) -> ParseResult<I, Self::Output> {
+        self.parse(input)
+    }
+}
+
+impl<I, O> ParserOnce<I> for CrashParser<O>
+where
+    I: Input,
+{
+    type Output = O;
+
+    fn parse_once(self, input: I) -> ParseResult<I, Self::Output> {
+        self.parse(input)
+    }
+}
+
+macro_rules! typed_fail {
+    ($type: ty) => {
+        crate::parse::parser::typed_fail_parser::<$type>()
+    };
+}
+pub(super) use typed_fail;
+
+/// A utility parser that always fails.
+///
+/// Mostly useful for testing purposes.
+pub fn typed_fail_parser<O>() -> FailParser<O> {
+    FailParser::new()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FailParser<O> {
+    _phantom: std::marker::PhantomData<O>,
+}
+
+impl<O> FailParser<O> {
+    fn new() -> Self {
+        Self {
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<I, O> Parser<I> for FailParser<O>
+where
+    I: Input,
+{
+    type Output = O;
+
+    fn parse(&self, input: I) -> ParseResult<I, Self::Output> {
+        Err(input)
+    }
+}
+
+impl<I, O> ParserMut<I> for FailParser<O>
+where
+    I: Input,
+{
+    type Output = O;
+
+    fn parse_mut(&mut self, input: I) -> ParseResult<I, Self::Output> {
+        Err(input)
+    }
+}
+
+impl<I, O> ParserOnce<I> for FailParser<O>
+where
+    I: Input,
+{
+    type Output = O;
+
+    fn parse_once(self, input: I) -> ParseResult<I, Self::Output> {
+        Err(input)
+    }
+}

--- a/src/parse/parser/map.rs
+++ b/src/parse/parser/map.rs
@@ -1,0 +1,108 @@
+use super::{Parser, ParserMut, ParserOnce};
+use crate::parse::input::{Input, ParseResult};
+
+pub trait Map<F>: Sized {
+    fn map(self, func: F) -> MapParser<Self, F>;
+}
+
+impl<F, T> Map<F> for T {
+    fn map(self, func: F) -> MapParser<Self, F> {
+        map(self, func)
+    }
+}
+
+pub fn map<P, F>(parser: P, func: F) -> MapParser<P, F> {
+    MapParser::new(parser, func)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MapParser<P, F> {
+    parser: P,
+    func: F,
+}
+
+impl<P, F> MapParser<P, F> {
+    fn new(parser: P, func: F) -> Self {
+        Self { parser, func }
+    }
+}
+
+impl<I, O, P, F> Parser<I> for MapParser<P, F>
+where
+    I: Input,
+    P: Parser<I>,
+    F: Fn(P::Output) -> O,
+{
+    type Output = O;
+
+    fn parse(&self, input: I) -> ParseResult<I, Self::Output> {
+        let (remaining, parsed) = self.parser.parse(input)?;
+        Ok((remaining, (self.func)(parsed)))
+    }
+}
+
+impl<I, O, P, F> ParserMut<I> for MapParser<P, F>
+where
+    I: Input,
+    P: ParserMut<I>,
+    F: FnMut(P::Output) -> O,
+{
+    type Output = O;
+
+    fn parse_mut(&mut self, input: I) -> ParseResult<I, Self::Output> {
+        let (remaining, parsed) = self.parser.parse_mut(input)?;
+        Ok((remaining, (self.func)(parsed)))
+    }
+}
+
+impl<I, O, P, F> ParserOnce<I> for MapParser<P, F>
+where
+    I: Input,
+    P: ParserOnce<I>,
+    F: FnOnce(P::Output) -> O,
+{
+    type Output = O;
+
+    fn parse_once(self, input: I) -> ParseResult<I, Self::Output> {
+        let (remaining, parsed) = self.parser.parse_once(input)?;
+        Ok((remaining, (self.func)(parsed)))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::parse::parser::take_chars;
+
+    #[test]
+    fn test_should_return_mapped_value_upon_success() {
+        let parser = take_chars(4).map(|s: &str| s.to_uppercase());
+        let result = parser.parse("test1234");
+        assert_eq!(Ok(("1234", "TEST".to_string())), result);
+    }
+
+    #[test]
+    fn test_should_not_be_called_upon_failure() {
+        let parser = take_chars(4).map(|_| panic!("you fucked up big time"));
+        let result = parser.parse("bad");
+        assert_eq!(Err("bad"), result);
+    }
+
+    #[test]
+    fn should_parse_mut_when_mapping_parser_mut() {
+        let mut parser = take_chars(4);
+        let parser = |input| parser.parse_mut(input);
+        let mut parser = parser.map(|s: &str| s.to_uppercase());
+        let result = parser.parse_mut("test1234");
+        assert_eq!(Ok(("1234", "TEST".to_string())), result);
+    }
+
+    #[test]
+    fn should_parse_once_when_mapping_parser_once() {
+        let parser = take_chars(4);
+        let parser = |input| parser.parse_once(input);
+        let parser = parser.map(|s: &str| s.to_ascii_uppercase());
+        let result = parser.parse_once("test1234");
+        assert_eq!(Ok(("1234", "TEST".to_string())), result);
+    }
+}

--- a/src/parse/parser/mod.rs
+++ b/src/parse/parser/mod.rs
@@ -1,0 +1,25 @@
+mod and;
+#[cfg(test)]
+mod fail;
+mod map;
+mod one_of;
+mod one_to_many;
+mod or;
+#[cfg(test)]
+mod take_chars;
+mod traits;
+mod validate;
+mod zero_to_many;
+
+pub use and::*;
+#[cfg(test)]
+pub use fail::*;
+pub use map::*;
+pub use one_of::*;
+pub use one_to_many::*;
+pub use or::*;
+#[cfg(test)]
+pub use take_chars::*;
+pub use traits::*;
+pub use validate::*;
+pub use zero_to_many::*;

--- a/src/parse/parser/one_of.rs
+++ b/src/parse/parser/one_of.rs
@@ -1,0 +1,307 @@
+use super::{Or, Parser, ParserMut, ParserOnce};
+use crate::parse::input::{Input, ParseResult};
+
+pub fn one_of<L>(parsers: L) -> OneOfParser<L> {
+    OneOfParser::new(parsers)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OneOfParser<L> {
+    parsers: L,
+}
+
+impl<L> OneOfParser<L> {
+    fn new(parsers: L) -> Self {
+        Self { parsers }
+    }
+}
+
+impl<I, T1, T2> Parser<I> for OneOfParser<(T1, T2)>
+where
+    I: Input,
+    T1: Parser<I>,
+    T2: Parser<I, Output = T1::Output>,
+{
+    type Output = T1::Output;
+
+    fn parse(&self, input: I) -> ParseResult<I, Self::Output> {
+        let left = |input: I| self.parsers.0.parse(input);
+        let right = |input: I| self.parsers.1.parse(input);
+        left.or(right).parse(input)
+    }
+}
+
+impl<I, T1, T2, T3> Parser<I> for OneOfParser<(T1, T2, T3)>
+where
+    I: Input,
+    T1: Parser<I>,
+    T2: Parser<I, Output = T1::Output>,
+    T3: Parser<I, Output = T1::Output>,
+{
+    type Output = T1::Output;
+
+    fn parse(&self, input: I) -> ParseResult<I, Self::Output> {
+        let first = |input: I| self.parsers.0.parse(input);
+        let second = |input: I| self.parsers.1.parse(input);
+        let third = |input: I| self.parsers.2.parse(input);
+        first.or(second).or(third).parse(input)
+    }
+}
+
+impl<I, T1, T2, T3, T4> Parser<I> for OneOfParser<(T1, T2, T3, T4)>
+where
+    I: Input,
+    T1: Parser<I>,
+    T2: Parser<I, Output = T1::Output>,
+    T3: Parser<I, Output = T1::Output>,
+    T4: Parser<I, Output = T1::Output>,
+{
+    type Output = T1::Output;
+
+    fn parse(&self, input: I) -> ParseResult<I, Self::Output> {
+        let first = |input: I| self.parsers.0.parse(input);
+        let second = |input: I| self.parsers.1.parse(input);
+        let third = |input: I| self.parsers.2.parse(input);
+        let fourth = |input: I| self.parsers.3.parse(input);
+        first.or(second).or(third).or(fourth).parse(input)
+    }
+}
+
+impl<I, T1, T2, T3, T4, T5> Parser<I> for OneOfParser<(T1, T2, T3, T4, T5)>
+where
+    I: Input,
+    T1: Parser<I>,
+    T2: Parser<I, Output = T1::Output>,
+    T3: Parser<I, Output = T1::Output>,
+    T4: Parser<I, Output = T1::Output>,
+    T5: Parser<I, Output = T1::Output>,
+{
+    type Output = T1::Output;
+
+    fn parse(&self, input: I) -> ParseResult<I, Self::Output> {
+        let first = |input: I| self.parsers.0.parse(input);
+        let second = |input: I| self.parsers.1.parse(input);
+        let third = |input: I| self.parsers.2.parse(input);
+        let fourth = |input: I| self.parsers.3.parse(input);
+        let fifth = |input: I| self.parsers.4.parse(input);
+        first.or(second).or(third).or(fourth).or(fifth).parse(input)
+    }
+}
+
+impl<I, T1, T2> ParserMut<I> for OneOfParser<(T1, T2)>
+where
+    I: Input,
+    T1: ParserMut<I>,
+    T2: ParserMut<I, Output = T1::Output>,
+{
+    type Output = T1::Output;
+
+    fn parse_mut(&mut self, input: I) -> ParseResult<I, Self::Output> {
+        let left = |input: I| self.parsers.0.parse_mut(input);
+        let right = |input: I| self.parsers.1.parse_mut(input);
+        left.or(right).parse_mut(input)
+    }
+}
+
+impl<I, T1, T2, T3> ParserMut<I> for OneOfParser<(T1, T2, T3)>
+where
+    I: Input,
+    T1: ParserMut<I>,
+    T2: ParserMut<I, Output = T1::Output>,
+    T3: ParserMut<I, Output = T1::Output>,
+{
+    type Output = T1::Output;
+
+    fn parse_mut(&mut self, input: I) -> ParseResult<I, Self::Output> {
+        let first = |input: I| self.parsers.0.parse_mut(input);
+        let second = |input: I| self.parsers.1.parse_mut(input);
+        let third = |input: I| self.parsers.2.parse_mut(input);
+        first.or(second).or(third).parse_mut(input)
+    }
+}
+
+impl<I, T1, T2, T3, T4> ParserMut<I> for OneOfParser<(T1, T2, T3, T4)>
+where
+    I: Input,
+    T1: ParserMut<I>,
+    T2: ParserMut<I, Output = T1::Output>,
+    T3: ParserMut<I, Output = T1::Output>,
+    T4: ParserMut<I, Output = T1::Output>,
+{
+    type Output = T1::Output;
+
+    fn parse_mut(&mut self, input: I) -> ParseResult<I, Self::Output> {
+        let first = |input: I| self.parsers.0.parse_mut(input);
+        let second = |input: I| self.parsers.1.parse_mut(input);
+        let third = |input: I| self.parsers.2.parse_mut(input);
+        let fourth = |input: I| self.parsers.3.parse_mut(input);
+        first.or(second).or(third).or(fourth).parse_mut(input)
+    }
+}
+
+impl<I, T1, T2, T3, T4, T5> ParserMut<I> for OneOfParser<(T1, T2, T3, T4, T5)>
+where
+    I: Input,
+    T1: ParserMut<I>,
+    T2: ParserMut<I, Output = T1::Output>,
+    T3: ParserMut<I, Output = T1::Output>,
+    T4: ParserMut<I, Output = T1::Output>,
+    T5: ParserMut<I, Output = T1::Output>,
+{
+    type Output = T1::Output;
+
+    fn parse_mut(&mut self, input: I) -> ParseResult<I, Self::Output> {
+        let first = |input: I| self.parsers.0.parse_mut(input);
+        let second = |input: I| self.parsers.1.parse_mut(input);
+        let third = |input: I| self.parsers.2.parse_mut(input);
+        let fourth = |input: I| self.parsers.3.parse_mut(input);
+        let fifth = |input: I| self.parsers.4.parse_mut(input);
+        first
+            .or(second)
+            .or(third)
+            .or(fourth)
+            .or(fifth)
+            .parse_mut(input)
+    }
+}
+
+impl<I, T1, T2> ParserOnce<I> for OneOfParser<(T1, T2)>
+where
+    I: Input,
+    T1: ParserOnce<I>,
+    T2: ParserOnce<I, Output = T1::Output>,
+{
+    type Output = T1::Output;
+
+    fn parse_once(self, input: I) -> ParseResult<I, Self::Output> {
+        let left = |input: I| self.parsers.0.parse_once(input);
+        let right = |input: I| self.parsers.1.parse_once(input);
+        left.or(right).parse_once(input)
+    }
+}
+
+impl<I, T1, T2, T3> ParserOnce<I> for OneOfParser<(T1, T2, T3)>
+where
+    I: Input,
+    T1: ParserOnce<I>,
+    T2: ParserOnce<I, Output = T1::Output>,
+    T3: ParserOnce<I, Output = T1::Output>,
+{
+    type Output = T1::Output;
+
+    fn parse_once(self, input: I) -> ParseResult<I, Self::Output> {
+        let first = |input: I| self.parsers.0.parse_once(input);
+        let second = |input: I| self.parsers.1.parse_once(input);
+        let third = |input: I| self.parsers.2.parse_once(input);
+        first.or(second).or(third).parse_once(input)
+    }
+}
+
+impl<I, T1, T2, T3, T4> ParserOnce<I> for OneOfParser<(T1, T2, T3, T4)>
+where
+    I: Input,
+    T1: ParserOnce<I>,
+    T2: ParserOnce<I, Output = T1::Output>,
+    T3: ParserOnce<I, Output = T1::Output>,
+    T4: ParserOnce<I, Output = T1::Output>,
+{
+    type Output = T1::Output;
+
+    fn parse_once(self, input: I) -> ParseResult<I, Self::Output> {
+        let first = |input: I| self.parsers.0.parse_once(input);
+        let second = |input: I| self.parsers.1.parse_once(input);
+        let third = |input: I| self.parsers.2.parse_once(input);
+        let fourth = |input: I| self.parsers.3.parse_once(input);
+        first.or(second).or(third).or(fourth).parse_once(input)
+    }
+}
+
+impl<I, T1, T2, T3, T4, T5> ParserOnce<I> for OneOfParser<(T1, T2, T3, T4, T5)>
+where
+    I: Input,
+    T1: ParserOnce<I>,
+    T2: ParserOnce<I, Output = T1::Output>,
+    T3: ParserOnce<I, Output = T1::Output>,
+    T4: ParserOnce<I, Output = T1::Output>,
+    T5: ParserOnce<I, Output = T1::Output>,
+{
+    type Output = T1::Output;
+
+    fn parse_once(self, input: I) -> ParseResult<I, Self::Output> {
+        let first = |input: I| self.parsers.0.parse_once(input);
+        let second = |input: I| self.parsers.1.parse_once(input);
+        let third = |input: I| self.parsers.2.parse_once(input);
+        let fourth = |input: I| self.parsers.3.parse_once(input);
+        let fifth = |input: I| self.parsers.4.parse_once(input);
+        first
+            .or(second)
+            .or(third)
+            .or(fourth)
+            .or(fifth)
+            .parse_once(input)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::parse::{
+        parser::{take_chars, typed_crash, typed_fail},
+        utils::alias,
+    };
+
+    alias!(fail, typed_fail![&'static str]);
+    alias!(crash, typed_crash![&'static str]);
+
+    #[test]
+    fn should_fail_if_all_parsers_fail() {
+        let parser = one_of((fail!(), fail!()));
+        assert_eq!(Err("test1234"), parser.parse("test1234"));
+    }
+
+    #[test]
+    fn should_succeed_and_not_call_other_parsers_when_first_succeeds() {
+        let parser = one_of((take_chars(4), crash!()));
+        let result = parser.parse("test1234");
+        assert_eq!(Ok(("1234", "test")), result);
+    }
+
+    #[test]
+    fn should_succeed_if_first_parser_fails_and_second_succeeds() {
+        let parser = one_of((fail!(), take_chars(4)));
+        let result = parser.parse("test1234");
+        assert_eq!(Ok(("1234", "test")), result);
+    }
+
+    #[test]
+    fn should_work_with_3_parsers() {
+        let parser = one_of((fail!(), fail!(), take_chars(4)));
+        let result = parser.parse("test1234");
+        assert_eq!(Ok(("1234", "test")), result);
+    }
+
+    #[test]
+    fn should_work_with_4_parsers() {
+        let parser = one_of((fail!(), fail!(), fail!(), take_chars(4)));
+        let result = parser.parse("test1234");
+        assert_eq!(Ok(("1234", "test")), result);
+    }
+
+    #[test]
+    fn should_parse_mut_with_parsers_mut() {
+        let mut left = take_chars(4);
+        let left = |input| left.parse_mut(input);
+        let mut parser = one_of((left, take_chars(4)));
+        let result = parser.parse_mut("test1234");
+        assert_eq!(Ok(("1234", "test")), result);
+    }
+
+    #[test]
+    fn should_parse_once_with_parsers_once() {
+        let left = take_chars(4);
+        let left = |input| left.parse_once(input);
+        let parser = one_of((left, take_chars(4)));
+        let result = parser.parse_once("test1234");
+        assert_eq!(Ok(("1234", "test")), result);
+    }
+}

--- a/src/parse/parser/one_to_many.rs
+++ b/src/parse/parser/one_to_many.rs
@@ -1,0 +1,152 @@
+use super::{Parser, ParserMut, ParserOnce};
+use crate::parse::input::{Input, ParseResult};
+
+pub trait OneToMany: Sized {
+    fn one_to_many(self) -> OneToManyParser<Self>;
+}
+
+impl<T> OneToMany for T {
+    fn one_to_many(self) -> OneToManyParser<Self> {
+        one_to_many(self)
+    }
+}
+
+pub fn one_to_many<T>(parser: T) -> OneToManyParser<T> {
+    OneToManyParser::new(parser)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OneToManyParser<P> {
+    parser: P,
+}
+
+impl<P> OneToManyParser<P> {
+    fn new(parser: P) -> Self {
+        Self { parser }
+    }
+}
+
+impl<I, P> Parser<I> for OneToManyParser<P>
+where
+    I: Input,
+    P: Parser<I>,
+{
+    type Output = Vec<P::Output>;
+
+    fn parse(&self, input: I) -> ParseResult<I, Vec<P::Output>> {
+        let first_result = self.parser.parse(input)?;
+        let mut remaining = first_result.0;
+        let mut results = vec![first_result.1];
+        let remaining = loop {
+            match self.parser.parse(remaining) {
+                Ok((next_remaining, parsed)) => {
+                    results.push(parsed);
+                    remaining = next_remaining;
+                }
+                Err(remaining) => break remaining,
+            }
+        };
+
+        Ok((remaining, results))
+    }
+}
+
+impl<I, P> ParserMut<I> for OneToManyParser<P>
+where
+    I: Input,
+    P: ParserMut<I>,
+{
+    type Output = Vec<P::Output>;
+
+    fn parse_mut(&mut self, input: I) -> ParseResult<I, Self::Output> {
+        let first_result = self.parser.parse_mut(input)?;
+        let mut remaining = first_result.0;
+        let mut results = vec![first_result.1];
+        let remaining = loop {
+            match self.parser.parse_mut(remaining) {
+                Ok((next_remaining, parsed)) => {
+                    results.push(parsed);
+                    remaining = next_remaining;
+                }
+                Err(remaining) => break remaining,
+            }
+        };
+
+        Ok((remaining, results))
+    }
+}
+
+// Only available if the parser can clone itself.
+impl<I, P> ParserOnce<I> for OneToManyParser<P>
+where
+    I: Input,
+    P: ParserOnce<I> + Clone,
+{
+    type Output = Vec<P::Output>;
+
+    fn parse_once(self, input: I) -> ParseResult<I, Self::Output> {
+        let first_result = self.parser.clone().parse_once(input)?;
+        let mut remaining = first_result.0;
+        let mut results = vec![first_result.1];
+        let remaining = loop {
+            match self.parser.clone().parse_once(remaining) {
+                Ok((next_remaining, parsed)) => {
+                    results.push(parsed);
+                    remaining = next_remaining;
+                }
+                Err(remaining) => break remaining,
+            }
+        };
+
+        Ok((remaining, results))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::parse::{
+        parser::{take_chars, typed_fail},
+        utils::alias,
+    };
+
+    alias!(fail, typed_fail![&'static str]);
+
+    #[test]
+    fn test_should_fail_if_cannot_parse_one() {
+        let parser = fail!().one_to_many();
+        assert_eq!(Err("test1234"), parser.parse("test1234"));
+    }
+
+    #[test]
+    fn test_should_succeed_if_it_can_parse_one() {
+        let parser = take_chars(4).one_to_many();
+        let result = parser.parse("test12");
+        assert_eq!(Ok(("12", vec!["test"])), result);
+    }
+
+    #[test]
+    fn test_should_return_as_many_values_as_possible() {
+        let parser = take_chars(4).one_to_many();
+        let result = parser.parse("test123456");
+        assert_eq!(Ok(("56", vec!["test", "1234"])), result);
+    }
+
+    #[test]
+    fn test_should_support_parser_mut() {
+        let mut parser = take_chars(4);
+        let parser = |input| parser.parse_mut(input);
+        let mut parser = parser.one_to_many();
+        let result = parser.parse_mut("test123456");
+        assert_eq!(Ok(("56", vec!["test", "1234"])), result);
+    }
+
+    #[test]
+    fn test_should_support_parser_once() {
+        let parser = take_chars(4);
+        let parser = |input| parser.parse_once(input);
+        let parser = parser.one_to_many();
+        let result = parser.parse_once("test123456");
+        assert_eq!(Ok(("56", vec!["test", "1234"])), result);
+    }
+}

--- a/src/parse/parser/or.rs
+++ b/src/parse/parser/or.rs
@@ -1,0 +1,127 @@
+use super::{Parser, ParserMut, ParserOnce};
+use crate::parse::input::{Input, ParseResult};
+
+pub trait Or<R>: Sized {
+    fn or(self, right: R) -> OrParser<Self, R>;
+}
+
+impl<R, T> Or<R> for T {
+    fn or(self, right: R) -> OrParser<Self, R> {
+        or(self, right)
+    }
+}
+
+pub fn or<L, R>(left: L, right: R) -> OrParser<L, R> {
+    OrParser::new(left, right)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OrParser<L, R> {
+    left: L,
+    right: R,
+}
+
+impl<L, R> OrParser<L, R> {
+    fn new(left: L, right: R) -> Self {
+        Self { left, right }
+    }
+}
+
+impl<I, L, R> Parser<I> for OrParser<L, R>
+where
+    I: Input,
+    L: Parser<I>,
+    R: Parser<I, Output = L::Output>,
+{
+    type Output = L::Output;
+
+    fn parse(&self, input: I) -> ParseResult<I, Self::Output> {
+        match self.left.parse(input) {
+            Ok((remaining, parsed)) => Ok((remaining, parsed)),
+            Err(input) => self.right.parse(input),
+        }
+    }
+}
+
+impl<I, L, R> ParserMut<I> for OrParser<L, R>
+where
+    I: Input,
+    L: ParserMut<I>,
+    R: ParserMut<I, Output = L::Output>,
+{
+    type Output = L::Output;
+
+    fn parse_mut(&mut self, input: I) -> ParseResult<I, Self::Output> {
+        match self.left.parse_mut(input) {
+            Ok((remaining, parsed)) => Ok((remaining, parsed)),
+            Err(remaining) => self.right.parse_mut(remaining),
+        }
+    }
+}
+
+impl<I, L, R> ParserOnce<I> for OrParser<L, R>
+where
+    I: Input,
+    L: ParserOnce<I>,
+    R: ParserOnce<I, Output = L::Output>,
+{
+    type Output = L::Output;
+
+    fn parse_once(self, input: I) -> ParseResult<I, Self::Output> {
+        match self.left.parse_once(input) {
+            Ok((remaining, parsed)) => Ok((remaining, parsed)),
+            Err(remaining) => self.right.parse_once(remaining),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::parse::{
+        parser::{take_chars, typed_crash, typed_fail},
+        utils::alias,
+    };
+
+    alias!(fail, typed_fail![&'static str]);
+    alias!(crash, typed_crash![&'static str]);
+
+    #[test]
+    fn test_rejects_when_both_reject() {
+        let parser = fail!().or(fail!());
+        let result = parser.parse("test");
+        assert_eq!(Err("test"), result);
+    }
+
+    #[test]
+    fn test_succeeds_when_left_succeeds_and_does_not_call_right() {
+        let parser = take_chars(4).or(crash!());
+        let result = parser.parse("test1234");
+        assert_eq!(Ok(("1234", "test")), result);
+    }
+
+    #[test]
+    fn test_succeeds_when_right_succeeds() {
+        let parser = fail!().or(take_chars(4));
+        let result = parser.parse("test1234");
+        assert_eq!(Ok(("1234", "test")), result);
+    }
+
+    #[test]
+    fn test_parse_mut_when_parsers_are_mut() {
+        let mut parser = take_chars(4);
+        let parser = |input| parser.parse_mut(input);
+        let mut parser = fail!().or(parser);
+        let result = parser.parse_mut("test1234");
+        assert_eq!(Ok(("1234", "test")), result);
+    }
+
+    #[test]
+    fn test_parse_once_when_parsers_are_once() {
+        let parser = take_chars(4);
+        let parser = |input| parser.parse_once(input);
+        let parser = fail!().or(parser);
+        let result = parser.parse_once("test1234");
+        assert_eq!(Ok(("1234", "test")), result);
+    }
+}

--- a/src/parse/parser/take_chars.rs
+++ b/src/parse/parser/take_chars.rs
@@ -1,0 +1,96 @@
+use super::{Parser, ParserMut, ParserOnce};
+use crate::parse::input::{Input, ParseQuantity, ParseResult};
+use nom::AsChar;
+
+pub fn take_chars(count: usize) -> TakeChars {
+    if count == 0 {
+        panic!("chars count must be greater than 0");
+    }
+    TakeChars::new(count)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TakeChars {
+    count: usize,
+}
+
+impl TakeChars {
+    fn new(count: usize) -> Self {
+        Self { count }
+    }
+}
+
+impl<'a, I> Parser<I> for TakeChars
+where
+    I: Input<Item = &'a str>,
+{
+    type Output = &'a str;
+
+    fn parse(&self, input: I) -> ParseResult<I, Self::Output> {
+        let Some(item) = input.first() else {
+            return input.failed();
+        };
+        if item.chars().count() < self.count {
+            return input.failed();
+        }
+        let offset = item.chars().take(self.count).map(|char| char.len()).sum();
+        input.parsed(ParseQuantity::Bytes(offset), &item[..offset])
+    }
+}
+
+impl<'a, I> ParserMut<I> for TakeChars
+where
+    I: Input<Item = &'a str>,
+{
+    type Output = &'a str;
+
+    fn parse_mut(&mut self, input: I) -> ParseResult<I, Self::Output> {
+        self.parse(input)
+    }
+}
+
+impl<'a, I> ParserOnce<I> for TakeChars
+where
+    I: Input<Item = &'a str>,
+{
+    type Output = &'a str;
+
+    fn parse_once(self, input: I) -> ParseResult<I, Self::Output> {
+        self.parse(input)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn should_panic_for_0() {
+        take_chars(0);
+    }
+
+    #[test]
+    fn should_reject_when_input_is_smaller() {
+        let input = "abc";
+        assert_eq!(Err("abc"), take_chars(4).parse(input));
+    }
+
+    #[test]
+    fn should_work_when_exhausting_input() {
+        let input = "abc";
+        assert_eq!(Ok(("", "abc")), take_chars(3).parse(input));
+    }
+
+    #[test]
+    fn should_work_when_subset_of_input() {
+        let input = "abc";
+        assert_eq!(Ok(("c", "ab")), take_chars(2).parse(input));
+    }
+
+    #[test]
+    fn should_work_with_unicode() {
+        let input = "wörd ist pöpsche";
+        assert_eq!(Ok((" ist pöpsche", "wörd")), take_chars(4).parse(input));
+    }
+}

--- a/src/parse/parser/traits.rs
+++ b/src/parse/parser/traits.rs
@@ -1,0 +1,63 @@
+use crate::parse::input::{Input, ParseResult};
+
+pub trait Parser<I>
+where
+    I: Input,
+{
+    type Output;
+    fn parse(&self, input: I) -> ParseResult<I, Self::Output>;
+}
+
+impl<I, O, T> Parser<I> for T
+where
+    I: Input,
+    T: Fn(I) -> ParseResult<I, O>,
+{
+    type Output = O;
+
+    fn parse(&self, input: I) -> ParseResult<I, Self::Output> {
+        self(input)
+    }
+}
+
+pub trait ParserMut<I>
+where
+    I: Input,
+{
+    type Output;
+
+    fn parse_mut(&mut self, input: I) -> ParseResult<I, Self::Output>;
+}
+
+impl<I, O, T> ParserMut<I> for T
+where
+    I: Input,
+    T: FnMut(I) -> ParseResult<I, O>,
+{
+    type Output = O;
+
+    fn parse_mut(&mut self, input: I) -> ParseResult<I, Self::Output> {
+        self(input)
+    }
+}
+
+pub trait ParserOnce<I>
+where
+    I: Input,
+{
+    type Output;
+
+    fn parse_once(self, input: I) -> ParseResult<I, Self::Output>;
+}
+
+impl<I, O, T> ParserOnce<I> for T
+where
+    I: Input,
+    T: FnOnce(I) -> ParseResult<I, O>,
+{
+    type Output = O;
+
+    fn parse_once(self, input: I) -> ParseResult<I, Self::Output> {
+        self(input)
+    }
+}

--- a/src/parse/parser/validate.rs
+++ b/src/parse/parser/validate.rs
@@ -1,0 +1,128 @@
+use super::{Parser, ParserMut, ParserOnce};
+use crate::parse::input::{Input, ParseResult};
+
+pub trait Validate<F>: Sized {
+    fn validate(self, func: F) -> ValidateParser<Self, F>;
+}
+
+impl<F, T> Validate<F> for T {
+    fn validate(self, func: F) -> ValidateParser<Self, F> {
+        validate(self, func)
+    }
+}
+
+pub fn validate<P, F>(parser: P, func: F) -> ValidateParser<P, F> {
+    ValidateParser::new(parser, func)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ValidateParser<P, F> {
+    parser: P,
+    func: F,
+}
+
+impl<P, F> ValidateParser<P, F> {
+    fn new(parser: P, func: F) -> Self {
+        Self { parser, func }
+    }
+}
+
+impl<I, P, F> Parser<I> for ValidateParser<P, F>
+where
+    I: Input,
+    P: Parser<I>,
+    F: Fn(&P::Output) -> bool,
+{
+    type Output = P::Output;
+
+    fn parse(&self, input: I) -> ParseResult<I, Self::Output> {
+        let (remaining, parsed) = self.parser.parse(input.clone())?;
+        if (self.func)(&parsed) {
+            Ok((remaining, parsed))
+        } else {
+            Err(input)
+        }
+    }
+}
+
+impl<I, P, F> ParserMut<I> for ValidateParser<P, F>
+where
+    I: Input,
+    P: ParserMut<I>,
+    F: FnMut(&P::Output) -> bool,
+{
+    type Output = P::Output;
+
+    fn parse_mut(&mut self, input: I) -> ParseResult<I, Self::Output> {
+        let (remaining, parsed) = self.parser.parse_mut(input.clone())?;
+        if (self.func)(&parsed) {
+            Ok((remaining, parsed))
+        } else {
+            Err(input)
+        }
+    }
+}
+
+impl<I, P, F> ParserOnce<I> for ValidateParser<P, F>
+where
+    I: Input,
+    P: ParserOnce<I>,
+    F: FnOnce(&P::Output) -> bool,
+{
+    type Output = P::Output;
+
+    fn parse_once(self, input: I) -> ParseResult<I, Self::Output> {
+        let (remaining, parsed) = self.parser.parse_once(input.clone())?;
+        if (self.func)(&parsed) {
+            Ok((remaining, parsed))
+        } else {
+            Err(input)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::parse::parser::fail::typed_fail;
+    use crate::parse::parser::take_chars;
+    use crate::parse::utils::alias;
+
+    alias!(fail, typed_fail![&'static str]);
+
+    #[test]
+    fn test_rejects_when_parser_rejects_and_does_not_call_predicate() {
+        let parser = fail!().validate(|_: &&str| {
+            panic!("fucked up big time here");
+        });
+        assert_eq!(Err("test1234"), parser.parse("test1234"));
+    }
+
+    #[test]
+    fn test_rejects_when_parser_succeeds_but_predicate_returns_false() {
+        let parser = take_chars(4).validate(|_: &&str| false);
+        assert_eq!(Err("test1234"), parser.parse("test1234"));
+    }
+
+    #[test]
+    fn test_succeeds_when_parser_succeeds_and_predicate_returns_true() {
+        let parser = take_chars(4).validate(|_: &&str| true);
+        assert_eq!(Ok(("1234", "test")), parser.parse("test1234"));
+    }
+
+    #[test]
+    fn test_should_support_parser_mut() {
+        let mut parser = take_chars(4);
+        let parser = |input| parser.parse_mut(input);
+        let mut parser = parser.validate(|_: &&str| true);
+        assert_eq!(Ok(("1234", "test")), parser.parse_mut("test1234"));
+    }
+
+    #[test]
+    fn test_should_support_parser_once() {
+        let parser = take_chars(4);
+        let parser = |input| parser.parse_once(input);
+        let parser = parser.validate(|_: &&str| true);
+        assert_eq!(Ok(("1234", "test")), parser.parse_once("test1234"));
+    }
+}

--- a/src/parse/segment/fenced_code/backticks.rs
+++ b/src/parse/segment/fenced_code/backticks.rs
@@ -4,7 +4,7 @@ use nom::combinator::eof;
 use nom::{IResult, combinator::consumed, error::ParseError};
 
 use crate::Segment;
-use crate::parse::traits::Parse;
+use crate::parse::traits::NomParse;
 use crate::parse::utils::{indented_by_less_than_4, line};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -27,8 +27,8 @@ impl<'a> BackticksFencedCodeOpeningSegment<'a> {
     }
 }
 
-impl<'a> Parse<'a> for BackticksFencedCodeOpeningSegment<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error> {
+impl<'a> NomParse<'a> for BackticksFencedCodeOpeningSegment<'a> {
+    fn nom_parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error> {
         consumed(line.and_then((
             indented_by_less_than_4,
             utils::backticks_fence,
@@ -72,8 +72,8 @@ impl<'a> BackticksFencedCodeClosingSegment<'a> {
     }
 }
 
-impl<'a> Parse<'a> for BackticksFencedCodeClosingSegment<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error> {
+impl<'a> NomParse<'a> for BackticksFencedCodeClosingSegment<'a> {
+    fn nom_parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error> {
         consumed(line.and_then((indented_by_less_than_4, utils::backticks_fence, space0, eof)))
             .map(|(segment, (indent, fence, _, _))| Self::new(segment, indent.len(), fence.len()))
             .parse(input)

--- a/src/parse/segment/fenced_code/tildes.rs
+++ b/src/parse/segment/fenced_code/tildes.rs
@@ -8,7 +8,7 @@ use nom::{
 use crate::{
     Segment,
     parse::{
-        traits::Parse,
+        traits::NomParse,
         utils::{indented_by_less_than_4, line},
     },
 };
@@ -33,8 +33,8 @@ impl<'a> TildesFencedCodeOpeningSegment<'a> {
     }
 }
 
-impl<'a> Parse<'a> for TildesFencedCodeOpeningSegment<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error> {
+impl<'a> NomParse<'a> for TildesFencedCodeOpeningSegment<'a> {
+    fn nom_parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error> {
         consumed(line.and_then((
             indented_by_less_than_4,
             utils::tildes_fence,
@@ -78,8 +78,8 @@ impl<'a> TildesFencedCodeClosingSegment<'a> {
     }
 }
 
-impl<'a> Parse<'a> for TildesFencedCodeClosingSegment<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error> {
+impl<'a> NomParse<'a> for TildesFencedCodeClosingSegment<'a> {
+    fn nom_parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error> {
         consumed(line.and_then((indented_by_less_than_4, utils::tildes_fence, space0, eof)))
             .map(|(segment, (indent, fence, _, _))| Self::new(segment, indent.len(), fence.len()))
             .parse(input)

--- a/src/parse/segment/setext_heading/equals.rs
+++ b/src/parse/segment/setext_heading/equals.rs
@@ -1,7 +1,7 @@
 use crate::{
     Segment,
     parse::{
-        traits::Parse,
+        traits::NomParse,
         utils::{indented_by_less_than_4, is_char, line},
     },
 };
@@ -26,8 +26,8 @@ impl<'a> SetextHeadingEqualsUnderlineSegment<'a> {
     }
 }
 
-impl<'a> Parse<'a> for SetextHeadingEqualsUnderlineSegment<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
+impl<'a> NomParse<'a> for SetextHeadingEqualsUnderlineSegment<'a> {
+    fn nom_parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
     where
         Self: Sized,
     {

--- a/src/parse/segment/setext_heading/hyphens.rs
+++ b/src/parse/segment/setext_heading/hyphens.rs
@@ -1,7 +1,7 @@
 use crate::{
     Segment,
     parse::{
-        traits::Parse,
+        traits::NomParse,
         utils::{indented_by_less_than_4, is_char, line},
     },
 };
@@ -26,8 +26,8 @@ impl<'a> SetextHeadingHyphensUnderlineSegment<'a> {
     }
 }
 
-impl<'a> Parse<'a> for SetextHeadingHyphensUnderlineSegment<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
+impl<'a> NomParse<'a> for SetextHeadingHyphensUnderlineSegment<'a> {
+    fn nom_parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
     where
         Self: Sized,
     {

--- a/src/parse/segment/setext_heading/mod.rs
+++ b/src/parse/segment/setext_heading/mod.rs
@@ -1,7 +1,7 @@
 mod equals;
 mod hyphens;
 
-use crate::{Segment, parse::traits::Parse};
+use crate::{Segment, parse::traits::NomParse};
 pub use equals::*;
 pub use hyphens::*;
 use nom::{IResult, Parser, branch::alt, error::ParseError};
@@ -33,14 +33,14 @@ impl<'a> From<SetextHeadingHyphensUnderlineSegment<'a>> for SetextHeadingUnderli
     }
 }
 
-impl<'a> Parse<'a> for SetextHeadingUnderlineSegment<'a> {
-    fn parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
+impl<'a> NomParse<'a> for SetextHeadingUnderlineSegment<'a> {
+    fn nom_parse<Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, Error>
     where
         Self: Sized,
     {
         alt((
-            SetextHeadingEqualsUnderlineSegment::parse.map(Self::from),
-            SetextHeadingHyphensUnderlineSegment::parse.map(Self::from),
+            SetextHeadingEqualsUnderlineSegment::nom_parse.map(Self::from),
+            SetextHeadingHyphensUnderlineSegment::nom_parse.map(Self::from),
         ))
         .parse(input)
     }

--- a/src/parse/test_utils.rs
+++ b/src/parse/test_utils.rs
@@ -1,34 +1,34 @@
 macro_rules! test_parse_macros {
     ($type:ty) => {
         macro_rules! failure_case {
-            ($test:ident, $segment:expr) => {
+            ($test:ident, $input:expr) => {
                 #[test]
                 fn $test() {
                     use crate::parse::traits::Parse;
 
-                    let result = <$type>::parse::<nom::error::Error<&str>>($segment);
+                    let result = <$type>::parse($input);
                     assert!(result.is_err(), "{:?}", result);
                 }
             };
         }
 
         macro_rules! success_case {
-                    ($test:ident, $segment:expr) => {
-                        success_case!($test, $segment, $segment, "");
+                    ($test:ident, $input:expr) => {
+                        success_case!($test, $input, $input, "");
                     };
-                    ($test:ident, $segment:expr, parsed => $parsed:expr) => {
-                        success_case!($test, $segment, parsed => $parsed, "");
+                    ($test:ident, $input:expr, parsed => $parsed:expr) => {
+                        success_case!($test, $input, parsed => $parsed, "");
                     };
-                    ($test:ident, $segment:expr, $parsed:expr, $remaining:expr) => {
-                        success_case!($test, $segment, parsed => <$type>::new($parsed), $remaining);
+                    ($test:ident, $input:expr, $parsed:expr, $remaining:expr) => {
+                        success_case!($test, $input, parsed => <$type>::new($parsed), $remaining);
                     };
-                    ($test:ident, $segment:expr, parsed => $parsed:expr, $remaining:expr) => {
+                    ($test:ident, $input:expr, parsed => $parsed:expr, $remaining:expr) => {
                         #[test]
                         fn $test() {
                             use crate::parse::traits::Parse;
 
                             assert_eq!(
-                                <$type>::parse::<nom::error::Error<&str>>($segment),
+                                <$type>::parse($input),
                                 Ok(($remaining, $parsed))
                             );
                         }

--- a/src/parse/utils.rs
+++ b/src/parse/utils.rs
@@ -1,4 +1,4 @@
-use super::traits::ParseWhole;
+use super::traits::NomParse;
 use crate::ast::BlankLine;
 use nom::{
     IResult, Parser,
@@ -12,6 +12,20 @@ use nom::{
     error::{Error, ParseError},
     sequence::terminated,
 };
+
+// TODO: should have that in a utility crate.
+#[cfg(test)]
+macro_rules! alias {
+    ($alias:ident, $expression:expr) => {
+        macro_rules! $alias {
+            () => {
+                $expression
+            };
+        }
+    };
+}
+#[cfg(test)]
+pub(super) use alias;
 
 /// Parses any escaped character sequence.
 ///
@@ -52,7 +66,10 @@ pub fn indented_by_less_than_4<'a, Error: ParseError<&'a str>>(
 ///
 /// It will inevitably return false if the input contains more than one line.
 pub fn is_blank_line(line: &str) -> bool {
-    BlankLine::parse_whole::<Error<&str>>(line).is_ok()
+    match BlankLine::nom_parse::<Error<&str>>(line) {
+        Ok((remaining, _)) => remaining.is_empty(),
+        Err(_) => false,
+    }
 }
 
 /// Returns a predicate that returns whether the character received is the


### PR DESCRIPTION
- Input trait
- Input implementation for str type. Might be made into its own
type for clarity later. Expecting to generate other input types
later as well. Such as QuoteContainerInput or something similar
(every container should have a matching Input type).
- Parse traits refactoring
  - New parse interface leveraging new Input and ParseResult types
  - Renamed legacy parse trait to NomParse
  - Blanket implementation of Parse for NomParse (forcing the single
  segment usage).
  - Removed uses of ParseWhole. Most were really supposed to call
  StrictParse and the one invocation that wasn't was adapted without.
- Updated all the multi segments parsing logic to stop implementing
NomParse in favor of Parse for correct behavior (will allow injecting
something like a QuoteContainerInput, for example)
