### PR TITLE
return TakeWhileParsers from space_or_tab

### DIFF
--- a/src/parse/ast/block/leaf/atx_heading.rs
+++ b/src/parse/ast/block/leaf/atx_heading.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::block::AtxHeading,
     parse::{
-        parser_utils::{at_least_1_space_or_tab, indented_by_less_than_4, line_ending_or_eof},
+        parser_utils::{indented_by_less_than_4, line_ending_or_eof, space_or_tab},
         traits::ParseLine,
     },
 };
@@ -41,7 +41,7 @@ fn hashes(input: &str) -> ParseResult<&str, u8> {
 /// A title will be invalid if it is not empty and does not start with a whitespace character.
 fn title<'a>(input: &'a str) -> ParseResult<&'a str, &'a str> {
     recognize(one_of((
-        recognize((at_least_1_space_or_tab, rest)),
+        recognize((space_or_tab().at_least(1), rest)),
         line_ending_or_eof,
     )))
     .map(|title_segment: &'a str| extract_title(title_segment))

--- a/src/parse/ast/block/leaf/blank_line.rs
+++ b/src/parse/ast/block/leaf/blank_line.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::block::BlankLine,
     parse::{
-        parser_utils::{at_least_1_space_or_tab, eof, line_ending, space_or_tab},
+        parser_utils::{eof, line_ending, space_or_tab},
         traits::ParseLine,
     },
 };
@@ -9,8 +9,8 @@ use parser::{Map, ParseResult, Parser, one_of, recognize};
 
 pub fn blank_line<'a>(input: &'a str) -> ParseResult<&'a str, BlankLine<'a>> {
     recognize(one_of((
-        (space_or_tab, line_ending),
-        (at_least_1_space_or_tab, eof),
+        (space_or_tab(), line_ending),
+        (space_or_tab().at_least(1), eof),
     )))
     .map(BlankLine::new)
     .parse(input)

--- a/src/parse/ast/block/leaf/thematic_break.rs
+++ b/src/parse/ast/block/leaf/thematic_break.rs
@@ -20,9 +20,9 @@ pub fn thematic_break<'a>(input: &'a str) -> ParseResult<&'a str, ThematicBreak<
 fn asterisks(input: &str) -> ParseResult<&str, &str> {
     recognize((
         tag("*"),
-        space_or_tab,
+        space_or_tab(),
         tag("*"),
-        space_or_tab,
+        space_or_tab(),
         tag("*"),
         take_while(is_one_of(&['*', ' ', '\t'])),
     ))
@@ -32,9 +32,9 @@ fn asterisks(input: &str) -> ParseResult<&str, &str> {
 fn hyphens(input: &str) -> ParseResult<&str, &str> {
     recognize((
         tag("-"),
-        space_or_tab,
+        space_or_tab(),
         tag("-"),
-        space_or_tab,
+        space_or_tab(),
         tag("-"),
         take_while(is_one_of(&['-', ' ', '\t'])),
     ))
@@ -44,9 +44,9 @@ fn hyphens(input: &str) -> ParseResult<&str, &str> {
 fn underscores(input: &str) -> ParseResult<&str, &str> {
     recognize((
         tag("_"),
-        space_or_tab,
+        space_or_tab(),
         tag("_"),
-        space_or_tab,
+        space_or_tab(),
         tag("_"),
         take_while(is_one_of(&['_', ' ', '\t'])),
     ))

--- a/src/parse/parser_utils/parsers.rs
+++ b/src/parse/parser_utils/parsers.rs
@@ -1,12 +1,12 @@
 use super::is_space_or_tab;
-use parser::{ParseResult, Parser, Validate, one_of, tag, take_while, validate};
+use parser::{ParseResult, Parser, TakeWhileParser, one_of, tag, take_while, validate};
 
 /// Parses and consumes all spaces and tabs at the beginning of the input,
 /// then verifies that the amount of whitespace is at least 4.
 ///
 /// This space scoring technique is described in the [CommonMark spec](https://spec.commonmark.org/0.31.2/#tabs).
 pub fn indented_by_at_least_4(input: &str) -> ParseResult<&str, &str> {
-    validate(space_or_tab, |s: &&str| s.contains("\t") || s.len() >= 4).parse(input)
+    validate(space_or_tab(), |s: &&str| s.contains("\t") || s.len() >= 4).parse(input)
 }
 
 /// Parses and consumes all spaces and tabs at the beginning of the input,
@@ -14,27 +14,15 @@ pub fn indented_by_at_least_4(input: &str) -> ParseResult<&str, &str> {
 ///
 /// Tabs are not allowed, as they count for 4 spaces. See here [CommonMark spec](https://spec.commonmark.org/0.31.2/#tabs).
 pub fn indented_by_less_than_4(input: &str) -> ParseResult<&str, &str> {
-    validate(space_or_tab, |s: &&str| !s.contains("\t") && s.len() < 4).parse(input)
+    validate(space_or_tab(), |s: &&str| !s.contains("\t") && s.len() < 4).parse(input)
 }
-
-// TODO: those should return take whiles instead, so they can be augmented with at least, at most, between.
 
 /// Consumes any amount of spaces or tabs.
 ///
 /// If the input doesn't start with a space or a tab, the parser will succeed and
 /// return an empty string as parsed.
-pub fn space_or_tab(input: &str) -> ParseResult<&str, &str> {
-    take_while(is_space_or_tab).parse(input)
-}
-
-/// Consumes at least one space or tab.
-///
-/// The parser will fail if the input does not start with a space or a tab,
-/// and will consume as many spaces or tabs as possible.
-pub fn at_least_1_space_or_tab(input: &str) -> ParseResult<&str, &str> {
+pub fn space_or_tab<E>() -> TakeWhileParser<E, impl Fn(char) -> bool> {
     take_while(is_space_or_tab)
-        .validate(|s: &&str| !s.is_empty())
-        .parse(input)
 }
 
 /// Consumes a line ending, which can be either `\n` or `\r\n`.
@@ -138,39 +126,17 @@ mod test {
 
         #[test]
         fn should_work_with_empty_string() {
-            assert_eq!(Ok(("", "")), space_or_tab(""));
+            assert_eq!(Ok(("", "")), space_or_tab().parse(""));
         }
 
         #[test]
         fn should_work_when_input_does_not_start_with_space_or_tab() {
-            assert_eq!(Ok(("abc", "")), space_or_tab("abc"));
+            assert_eq!(Ok(("abc", "")), space_or_tab().parse("abc"));
         }
 
         #[test]
         fn should_work_with_spaces_or_tabs() {
-            assert_eq!(Ok(("toto", "  \t\t ")), space_or_tab("  \t\t toto"));
-        }
-    }
-
-    mod at_least_1_space_or_tab {
-        use super::*;
-
-        #[test]
-        fn should_fail_with_empty_string() {
-            assert!(at_least_1_space_or_tab("").is_err());
-        }
-
-        #[test]
-        fn should_fail_with_non_whitespace_character() {
-            assert!(at_least_1_space_or_tab("a").is_err());
-        }
-
-        #[test]
-        fn should_work_with_spaces_or_tabs() {
-            assert_eq!(
-                Ok(("toto", "  \t\t ")),
-                at_least_1_space_or_tab("  \t\t toto")
-            );
+            assert_eq!(Ok(("toto", "  \t\t ")), space_or_tab().parse("  \t\t toto"));
         }
     }
 

--- a/src/parse/segment/fenced_code/backticks.rs
+++ b/src/parse/segment/fenced_code/backticks.rs
@@ -57,7 +57,7 @@ pub fn backticks_fenced_code_closing_segment<'a>(
     consumed((
         indented_by_less_than_4,
         utils::backticks_fence,
-        space_or_tab,
+        space_or_tab(),
         line_ending_or_eof,
     ))
     .map(

--- a/src/parse/segment/fenced_code/tildes.rs
+++ b/src/parse/segment/fenced_code/tildes.rs
@@ -61,7 +61,7 @@ pub fn tildes_fenced_code_closing_segment<'a>(
     consumed((
         indented_by_less_than_4,
         utils::tildes_fence,
-        space_or_tab,
+        space_or_tab(),
         line_ending_or_eof,
     ))
     .map(


### PR DESCRIPTION
- And should be the convention for functions that just instrument
take_while. This is so they all have the same verbiage to express
"at least" and "at once"
